### PR TITLE
Implementation of simulated tactile sensors

### DIFF
--- a/cob_gazebo/ros/launch/robot.launch
+++ b/cob_gazebo/ros/launch/robot.launch
@@ -10,4 +10,7 @@
   <!-- services for simulation (e.g.: stop for simulation)-->
   <node pkg="cob_gazebo" type="gazebo_services.py" name="gazebo_services" cwd="node" respawn="false" output="screen" />
 
+  <!-- sdh simulated tactile sensors -->
+  <include file="$(find cob_simulated_tactile_sensors)/launch/gazebo_virtual_tactile_sensors.launch" />
+
 </launch>

--- a/cob_simulated_tactile_sensors/CMakeLists.txt
+++ b/cob_simulated_tactile_sensors/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 2.4.6)
+include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
+
+# Set the build type.  Options are:
+#  Coverage       : w/ debug symbols, w/o optimization, w/ code-coverage
+#  Debug          : w/ debug symbols, w/o optimization
+#  Release        : w/o debug symbols, w/ optimization
+#  RelWithDebInfo : w/ debug symbols, w/ optimization
+#  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
+#set(ROS_BUILD_TYPE RelWithDebInfo)
+
+rosbuild_init()
+
+#set the default path for built executables to the "bin" directory
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
+#set the default path for built libraries to the "lib" directory
+set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
+
+#uncomment if you have defined messages
+#rosbuild_genmsg()
+#uncomment if you have defined services
+#rosbuild_gensrv()
+
+#common commands for building c++ executables and libraries
+#rosbuild_add_library(${PROJECT_NAME} src/example.cpp)
+#target_link_libraries(${PROJECT_NAME} another_library)
+#rosbuild_add_boost_directories()
+#rosbuild_link_boost(${PROJECT_NAME} thread)
+#rosbuild_add_executable(example examples/example.cpp)
+#target_link_libraries(example ${PROJECT_NAME})

--- a/cob_simulated_tactile_sensors/Makefile
+++ b/cob_simulated_tactile_sensors/Makefile
@@ -1,0 +1,1 @@
+include $(shell rospack find mk)/cmake.mk

--- a/cob_simulated_tactile_sensors/launch/gazebo_virtual_tactile_sensors.launch
+++ b/cob_simulated_tactile_sensors/launch/gazebo_virtual_tactile_sensors.launch
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<launch>
+
+	<node pkg="cob_simulated_tactile_sensors" type="gazebo_virtual_tactile_sensors.py" name="tactile_sensors" ns="sdh_controller" output="screen">
+		<!-- The number of patches on the tactile sensor in the direction perpendicular to the finger -->
+		<param name="cells_x" value="6" />
+
+		<!-- The number of patches on the tactile sensor along the direction of the finger -->
+		<param name="cells_y" value="14" />
+		
+		<!-- The change of output in one patch per Newton -->
+		<param name="sensitivity" value="350" />
+		
+		<!-- The maximum output value of one patch -->
+		<param name="output_range" value="3500.0" />
+		
+		<!-- Length of the moving average filter which smoothes simulation output -->
+		<param name="filter_length" value="10" />
+		
+		<!-- Remap the output topic -->
+		<remap from="tactile_data" to="/sdh_controller/tactile_data" />
+		
+		<!-- Remap the bumper subscriptions to the simulation -->
+		<remap from="finger_12/state" to="/sdh_finger_12_bumper/state" />
+		<remap from="finger_13/state" to="/sdh_finger_13_bumper/state" />
+		<remap from="thumb_2/state" to="/sdh_thumb_2_bumper/state" />
+		<remap from="thumb_3/state" to="/sdh_thumb_3_bumper/state" />
+		<remap from="finger_22/state" to="/sdh_finger_22_bumper/state" />
+		<remap from="finger_23/state" to="/sdh_finger_23_bumper/state" />
+	</node>
+
+</launch>

--- a/cob_simulated_tactile_sensors/mainpage.dox
+++ b/cob_simulated_tactile_sensors/mainpage.dox
@@ -1,0 +1,26 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b cob_simulated_tactile_sensors is ... 
+
+<!-- 
+Provide an overview of your package.
+-->
+
+
+\section codeapi Code API
+
+<!--
+Provide links to specific auto-generated API documentation within your
+package that is of particular interest to a reader. Doxygen will
+document pretty much every part of your code, so do your best here to
+point the reader to the actual API.
+
+If your codebase is fairly large or has different sets of APIs, you
+should use the doxygen 'group' tag to keep these APIs together. For
+example, the roscpp documentation has 'libros' group.
+-->
+
+
+*/

--- a/cob_simulated_tactile_sensors/manifest.xml
+++ b/cob_simulated_tactile_sensors/manifest.xml
@@ -1,0 +1,57 @@
+<package>
+  <description brief="cob_simulated_tactile_sensors">
+
+     This package provides simulated tactile sensors for the Schunk Dextrous
+     Hand (SDH) which is mounted on the Care-O-bot arm. The node subscribes to
+     the Gazebo bumper topics of the SDH. It transforms the Gazebo feedback to
+     the "tactile_data" topic to provide the same tactile sensor interface as
+     the cob_sdh package.
+     
+     The following parameters can be set:
+     * cells_x: The number of patches on the tactile sensor in the direction
+                perpendicular to the finger. Defaults to 6.
+     * cells_y: The number of patches on the tactile sensor along the direction
+                of the finger. Defaults to 14.
+     * output_range: The maximum output value of one patch. Defaults to 3500.
+     * sensitivity: The change of output in one patch per Newton. Defaults to
+                    350. The sensitivity can be approximated by the following
+                    formula: S = output_range / (measurement_range * cell_area)
+                    - The measurement range of the tactile pads is 250 kPa (from
+                      the data sheet).
+                    - The output range can be determined by experiment from the
+                      real SDH. It is about 3500.
+                    - The cell area is the size of one patch. Length and width
+                      of the area are determined by dividing the length/width
+                      of the collision surface by the number of cells in the
+                      respective direction.
+                      Important: In most cases this is NOT the cell area that is
+                                 given in the data sheet!
+     * filter_length: The length of the moving average filter which smoothes
+                      the values from simulation. Defaults to 10.
+     
+     The node subscribes to the following topics to receive data from the
+     simulation:
+     * finger_12/state
+     * finger_13/state
+     * thumb_2/state
+     * thumb_3/state
+     * finger_22/state
+     * finger_23/state
+     
+     The node publishes the processed data on the following topic:
+     * tactile_data
+     
+     The simulated bumper must obtain the collision data in the link that the
+     sensor is attached to. This is achieved by setting the "frameName" property
+     in the gazebo_ros_bumper controller.
+
+  </description>
+  <author>Sven Schneider</author>
+  <license>BSD</license>
+  <review status="unreviewed" notes=""/>
+  <url>http://ros.org/wiki/cob_simulated_tactile_sensors</url>
+  <depend package="rospy"/>
+  <depend package="cob_sdh"/>
+  <depend package="gazebo_plugins"/>
+
+</package>

--- a/cob_simulated_tactile_sensors/scripts/gazebo_virtual_tactile_sensors.py
+++ b/cob_simulated_tactile_sensors/scripts/gazebo_virtual_tactile_sensors.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+import roslib; roslib.load_manifest('cob_simulated_tactile_sensors')
+import rospy
+import math
+from cob_sdh.msg import *
+from gazebo_plugins.msg import *
+from geometry_msgs.msg import *
+
+
+class GazeboTactilePad():
+	
+	def __init__(self, topic_name, finger_length, finger_width):
+		self.finger_length = finger_length
+		self.finger_width = finger_width
+		
+		# get parameters from parameter server
+		self.cells_x = rospy.get_param("~cells_x", 6)
+		self.cells_y = rospy.get_param("~cells_y", 14)
+		rospy.logdebug("size of the tactile matrix is %ix%i patches", self.cells_x, self.cells_y)
+		
+		self.sensitivity = rospy.get_param("~sensitivity", 350.0)
+		rospy.logdebug("sensitivity: %f", self.sensitivity)
+		
+		self.range = rospy.get_param("~output_range", 3500)
+		rospy.logdebug("output range: %f", self.range)
+		
+		self.filter_length = rospy.get_param("~filter_length", 10)
+		rospy.logdebug("filter length: %i", self.filter_length)
+		
+		rospy.Subscriber(topic_name, ContactsState, self.contact_callback)
+		rospy.logdebug("subscribed to bumper states topic: %s", topic_name)
+		
+		self.smoothed_matrix = self.create_empty_force_matrix()
+
+
+	'''
+	Update the pad with the Gazebo contact information.
+	
+	:param states: gazebo_plugins.msg.ContactsState
+	'''
+	def contact_callback(self, states):
+		matrix = self.create_empty_force_matrix()
+		matrix = self.update(states, matrix)
+		matrix = self.smooth(matrix)
+		matrix = self.time_average(self.smoothed_matrix, matrix, self.filter_length)
+		
+		self.smoothed_matrix = matrix
+
+
+	'''
+	Update the provided matrix with the contact information from the Gazebo
+	simulator.
+	
+	:param states: gazebo_plugins.msg.ContactsState
+	:param matrix: Float[]
+	'''
+	def update(self, states, matrix):
+		# no contact, so we don't update the matrix
+		if (len(states.states) == 0):
+			return matrix
+		
+		for i in range(len(states.states)):
+			state = states.states[i]
+			for j in range(len(state.contact_positions)):
+				# check if the contact is on the same side as the sensor
+				if (state.contact_positions[j].x < 0.0):
+					continue
+				
+				# normalize the contact position along the tactile sensor
+				# we assume that the tactile sensor occupies the complete
+				# surface of the inner finger side, so finger size is equal to
+				# sensor size
+				normalized_x = (state.contact_positions[j].y / self.finger_width) + 0.5
+				normalized_y = state.contact_positions[j].z / self.finger_length
+				
+				# from the normalized coordinate we can now determine the index
+				# of the tactile patch that is activated by the contact
+				x = round(normalized_x * self.cells_x)
+				y = round(normalized_y * self.cells_y)
+				
+				force = -state.wrenches[j].force.x
+				if (force < 0.0): force = 0.0
+				
+				index = int(self.get_index(x, y))
+				
+				matrix[index] += force
+		
+		return matrix
+
+
+	'''
+	Create a new matrix that contains the current force on each cell. Initialize
+	all cells with zeros.
+	
+	:return: Float[]
+	'''
+	def create_empty_force_matrix(self):
+		matrix = []
+		for i in range(self.cells_x * self.cells_y):
+			matrix.append(0.0)
+		
+		return matrix
+
+
+	'''
+	Run a moving average on the provided matrix.
+	
+	:param matrix: Float[]
+	:return: Float[]
+	'''
+	def smooth(self, matrix):
+		smoothed_matrix = self.create_empty_force_matrix()
+		
+		for x in range(0, self.cells_x):
+			for y in range(0, self.cells_y):
+				sum = 0.0
+				count = 0
+				for dx in range(-1, 2):
+					for dy in range(-1, 2):
+						index_x = x + dx
+						index_y = y + dy
+						
+						if (index_x < 0 or index_x >= self.cells_x): continue
+						if (index_y < 0 or index_y >= self.cells_y): continue
+						
+						index = self.get_index(index_x, index_y)
+						sum += matrix[index]
+						count += 1
+				index = self.get_index(x, y)
+				smoothed_matrix[index] = sum / count
+		
+		return smoothed_matrix
+
+
+	'''
+	Calculate the average matrix from the force buffer.
+	
+	:return: Float[]
+	'''
+	def time_average(self, matrix_buffer, current_matrix, filter_length):
+		matrix = self.create_empty_force_matrix()
+		sample_factor = 1.0 / filter_length
+		
+		for i in range(self.cells_x * self.cells_y):
+			force = (1.0 - sample_factor) * matrix_buffer[i]
+			force += sample_factor * current_matrix[i]
+			matrix[i] = force
+		
+		return matrix
+
+
+	'''
+	Get the current forces as tactile matrix. matrix_id is the identifier of the
+	tactile matrix and determines which pad produced the data.
+	
+	:param matrix_id: Integer
+	:return: cob_sdh.msg.TactileMatrix
+	'''
+	def tactile_matrix(self, matrix_id):
+		matrix = TactileMatrix()
+		matrix.matrix_id = matrix_id
+		matrix.cells_x = self.cells_x
+		matrix.cells_y = self.cells_y
+		
+		m = self.smoothed_matrix
+		
+		for i in range(self.cells_x * self.cells_y):
+			force = m[i] * self.sensitivity
+			if (force < 0.0): force = 0.0
+			if (force > self.range): force = self.range
+			matrix.tactile_array.append(force)
+				
+		return matrix
+
+
+	'''
+	Map the two-dimensional coordinate of a tactile patch to an index in the
+	one-dimensional data array. The coordinates are bound to the upper and lower
+	limits.
+	
+	:param x: Integer
+	:param y: Integer
+	:return: Integer
+	'''
+	def get_index(self, x, y):
+		y = self.cells_y - y - 1
+		if (x >= self.cells_x): x = self.cells_x - 1
+		if (x < 0): x = 0
+		if (y >= self.cells_y): y = self.cells_y - 1
+		if (y < 0): y = 0
+		
+		return y * self.cells_x + x
+
+
+
+
+class GazeboVirtualTactileSensor():
+	'''
+	Constants that determine which indices the finger parts have in the
+	cob_sdh.msg.TactileSensor matrix.
+	'''
+	ID_FINGER_12 = 0
+	ID_FINGER_13 = 1
+	ID_THUMB_2 = 2
+	ID_THUMB_3 = 3
+	ID_FINGER_22 = 4
+	ID_FINGER_23 = 5
+	
+	
+	def __init__(self):
+		self.pads = []
+		self.pads.append(GazeboTactilePad("finger_12/state", 0.0865, 0.03))
+		self.pads.append(GazeboTactilePad("finger_13/state", 0.0675, 0.03))
+		self.pads.append(GazeboTactilePad("thumb_2/state", 0.0865, 0.03))
+		self.pads.append(GazeboTactilePad("thumb_3/state", 0.0675, 0.03))
+		self.pads.append(GazeboTactilePad("finger_22/state", 0.0865, 0.03))
+		self.pads.append(GazeboTactilePad("finger_23/state", 0.0675, 0.03))
+		
+		self.pub = rospy.Publisher("tactile_data", TactileSensor)
+		rospy.loginfo("'tactile_data' topic advertized")
+
+
+	'''
+	Publish the current state of the simulated tactile sensors.
+	'''
+	def publish(self):
+		msg = TactileSensor()
+		msg.header.stamp = rospy.Time.now()
+		for i in range(6):
+			msg.tactile_matrix.append(self.pads[i].tactile_matrix(i))
+		self.pub.publish(msg)
+
+
+
+
+if __name__ == "__main__":
+	rospy.init_node('tactile_sensors')
+	rospy.sleep(0.5)
+	
+	sensor = GazeboVirtualTactileSensor()
+	
+	while not rospy.is_shutdown():
+		sensor.publish()
+		rospy.sleep(0.05)


### PR DESCRIPTION
Currently, there is no support for tactile sensors which are mounted on the SDH in simulation.

The first commit in this pull request adds simulated tactile sensors that publish the pressure values. Pressure is calculated from the bumpers that are attached to the SDH fingers in simulation.

The second commit starts the simulated tactile sensors when Gazebo is started.
