### PR TITLE
Set GAZEBO_MODEL_PATH from within launch file

### DIFF
--- a/cob_bringup_sim/launch/robot.launch
+++ b/cob_bringup_sim/launch/robot.launch
@@ -23,7 +23,9 @@
 	<include file="$(arg pkg_env_config)/upload_object_locations.launch">
 		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
-
+	
+	<env name="GAZEBO_MODEL_PATH" value="$(find cob_gazebo_worlds)/Media/models:$(optenv GAZEBO_MODEL_PATH)"/>
+	
 	<!-- startup simulated world -->
 	<include file="$(find cob_gazebo_worlds)/launch/$(arg robot_env).launch">
 		<arg name="paused" value="$(arg paused)" />


### PR DESCRIPTION
this is required for e.g. ipa-factory
if not set in launch file, GAZEBO_MODEL_PATH needs to be set manually - which is not obvious to the user.
