### PR TITLE
[Indigo] introduce launchfile argument for -J option of spawn_model

### DIFF
--- a/cob_bringup_sim/launch/robot.launch
+++ b/cob_bringup_sim/launch/robot.launch
@@ -6,6 +6,7 @@
 	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
 	<arg name="pkg_robot_config" default="$(find cob_default_robot_config)"/>
 	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
+	<arg name="initial_config" default=""/>
 	
 	<arg name="paused" default="false"/>
 	<arg name="use_sim_time" default="true"/>
@@ -36,6 +37,7 @@
 	<include file="$(find cob_gazebo)/launch/robot.launch" >
 		<arg name="robot" value="$(arg robot)" />
 		<arg name="paused" value="$(arg paused)" />
+		<arg name="initial_config" value="$(arg initial_config)"/>
 	</include>
 
 </launch>

--- a/cob_gazebo/launch/robot.launch
+++ b/cob_gazebo/launch/robot.launch
@@ -3,6 +3,7 @@
 
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
 	<arg name="paused" default="false"/>
+	<arg name="initial_config" default=""/>
 
 	<!-- send robot urdf to param server -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -10,7 +11,7 @@
 	</include>
 
 	<!-- push robot_description to factory and spawn robot in gazebo -->
-	<node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -z 0.1 " respawn="false" output="screen" />
+	<node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -z 0.1 $(arg initial_config)" respawn="false" output="screen" />
 
 	<!-- start gazebo controllers -->
 	<include file="$(find cob_controller_configuration_gazebo)/launch/robots/default_controllers_$(arg robot).launch" >


### PR DESCRIPTION
This PR adds a new optional launch file argument for `cob_bringup_sim robot.launch` that allows to set joint to initial configs other than 0.0.
The argument can than be used like this:

```
roslaunch cob_bringup_sim robot.launch robot:=raw3-1 robot_env:=empty initial_config:='-J arm_shoulder_pan_joint 0.0 -J arm_shoulder_lift_joint -1.5707 -J arm_elbow_joint 0.0 -J arm_wrist_1_joint -1.5707 -J arm_wrist_2_joint 0.0 -J arm_wrist_3_joint 0.0'
```

(This feature is currently being re-added to `gazebo_ros_pkgs`....thus please hold this PR for a little longer...)
