### PR TITLE
fix laserscan max range bug in simulation

### DIFF
--- a/cob_bringup_sim/launch/robot.launch
+++ b/cob_bringup_sim/launch/robot.launch
@@ -28,6 +28,7 @@
 	<!-- startup simulated robot -->
 	<include file="$(find cob_gazebo)/launch/robot.launch" >
 		<arg name="robot" value="$(arg robot)" />
+		<arg name="robot_env" value="$(arg robot_env)" />
 		<arg name="pkg_robot_config" value="$(arg pkg_robot_config)" />
 		<arg name="paused" value="$(arg paused)" />
 		<arg name="initial_config" value="$(arg initial_config)"/>

--- a/cob_gazebo/launch/robot.launch
+++ b/cob_gazebo/launch/robot.launch
@@ -3,6 +3,7 @@
 
 	<!-- define arguments -->
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
 	<arg name="pkg_robot_config" default="$(find cob_default_robot_config)"/>
 	<arg name="paused" default="false"/>
 	<arg name="initial_config" default=""/>
@@ -11,14 +12,14 @@
 	<include file="$(arg pkg_robot_config)/upload_param.launch">
 		<arg name="robot" value="$(arg robot)" />
 	</include>
-	
+
 	<!-- send robot urdf to param server -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
 		<arg name="robot" value="$(arg robot)" />
 	</include>
 
 	<!-- push robot_description to factory and spawn robot in gazebo -->
-	<node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -z 0.1 $(arg initial_config) -wait ipa-apartment" respawn="false" output="screen" />
+	<node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -z 0.1 $(arg initial_config) -wait $(arg robot_env)" respawn="false" output="screen" />
 
 	<!-- start gazebo controllers -->
 	<include file="$(find cob_controller_configuration_gazebo)/launch/robots/default_controllers_$(arg robot).launch" >

--- a/cob_gazebo/launch/robot.launch
+++ b/cob_gazebo/launch/robot.launch
@@ -18,7 +18,7 @@
 	</include>
 
 	<!-- push robot_description to factory and spawn robot in gazebo -->
-	<node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -z 0.1 $(arg initial_config)" respawn="false" output="screen" />
+	<node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -z 0.1 $(arg initial_config) -wait ipa-apartment" respawn="false" output="screen" />
 
 	<!-- start gazebo controllers -->
 	<include file="$(find cob_controller_configuration_gazebo)/launch/robots/default_controllers_$(arg robot).launch" >


### PR DESCRIPTION
gazebo laserscanner plugin has a bug measuring the environment if the robot is spawned before the whole environment is ready. This forces spawning the robot after the environment ready.
I had this problem and this solved it for me.
