### PR TITLE
Add reflector marker round

### DIFF
--- a/cob_gazebo_objects/objects/reflector_marker.sdf
+++ b/cob_gazebo_objects/objects/reflector_marker.sdf
@@ -1,6 +1,7 @@
 <?xml version='1.0'?>
 <sdf version='1.4'>
   <model name="reflector_marker">
+    <static>true</static>
     <link name='link'>
       <pose>0 0 0.115 0 0 0</pose>
       <inertial>

--- a/cob_gazebo_objects/objects/reflector_marker_round.sdf
+++ b/cob_gazebo_objects/objects/reflector_marker_round.sdf
@@ -1,0 +1,47 @@
+<?xml version='1.0'?>
+<sdf version='1.4'>
+  <model name="reflector_marker">
+    <static>true</static>
+    <link name='link'>
+      <pose>0 0 0.115 0 0 0</pose>
+      <inertial>
+        <mass>0.390</mass>
+        <inertia>
+          <ixx>0.00058</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00058</iyy>
+          <iyz>0</iyz>
+          <izz>0.00019</izz>
+        </inertia>
+      </inertial>
+      <collision name='collision'>
+        <pose>0 0 0.010000 0 0 0</pose>
+        <laser_retro>2000</laser_retro>
+        <geometry>
+          <cylinder>
+            <radius>0.050000</radius>
+            <length>0.300000</length>
+          </cylinder>
+        </geometry>
+      </collision>
+
+      <visual name='visual'>
+        <pose>0 0 0.010000 0 0 0</pose>
+        <laser_retro>2000</laser_retro>
+        <geometry>
+          <cylinder>
+            <radius>0.050000</radius>
+            <length>0.300000</length>
+          </cylinder>
+        </geometry>
+
+        <material>
+          <script>
+            <name>ReflMarker/Diffuse</name>
+          </script>
+        </material>
+      </visual>
+    </link>     
+  </model>
+</sdf>


### PR DESCRIPTION
apparently `cob_docking` has issues with rectangular reflector markers when moving too close, i.e. the reflections are detected on both flanks or not at all....thus, here are round markers
@souravran