### PR TITLE
correct marker radius

### DIFF
--- a/cob_gazebo_objects/objects/reflector_marker_round.sdf
+++ b/cob_gazebo_objects/objects/reflector_marker_round.sdf
@@ -20,7 +20,7 @@
         <laser_retro>2000</laser_retro>
         <geometry>
           <cylinder>
-            <radius>0.050000</radius>
+            <radius>0.025000</radius>
             <length>0.300000</length>
           </cylinder>
         </geometry>
@@ -31,7 +31,7 @@
         <laser_retro>2000</laser_retro>
         <geometry>
           <cylinder>
-            <radius>0.050000</radius>
+            <radius>0.025000</radius>
             <length>0.300000</length>
           </cylinder>
         </geometry>


### PR DESCRIPTION
forgot to actually push this commit to #141 
although it works with the 5cm radius as well, this is the correct size...
(will be replaced by actual charging station soon anyway)