### PR TITLE
remove kitchen unit

### DIFF
--- a/cob_gazebo_worlds/urdf/ipa-apartment/ipa-apartment.urdf.xacro
+++ b/cob_gazebo_worlds/urdf/ipa-apartment/ipa-apartment.urdf.xacro
@@ -74,8 +74,8 @@
     <xacro:cabinets name="cabinets">
     </xacro:cabinets>
 
-    <xacro:kitchen name="kitchen">
-    </xacro:kitchen>
+    <!--xacro:kitchen name="kitchen">
+    </xacro:kitchen-->
 
     <xacro:wall_ipa name="wall_ipa">
     </xacro:wall_ipa>


### PR DESCRIPTION
because it blocks spawning the charging station